### PR TITLE
fix(security): tx-sender consistency, wallet auth, SIP-018 hash

### DIFF
--- a/contracts/reputation-registry.clar
+++ b/contracts/reputation-registry.clar
@@ -1,5 +1,5 @@
 ;; title: reputation-registry
-;; version: 1.0.0
+;; version: 2.0.0
 ;; summary: ERC-8004 Reputation Registry - Client feedback for agents with SIP-018 and on-chain authorization.
 ;; description: Allows clients to give feedback on agents. Supports both on-chain approval and SIP-018 signed authorization.
 
@@ -56,7 +56,7 @@
 
 (define-public (approve-client (agent-id uint) (client principal) (index-limit uint))
   (let (
-    (caller contract-caller)
+    (caller tx-sender)
   )
     ;; Verify caller is owner or operator
     (asserts! (is-authorized agent-id caller) ERR_NOT_AUTHORIZED)
@@ -87,7 +87,7 @@
   (feedback-hash (buff 32))
 )
   (let (
-    (caller contract-caller)
+    (caller tx-sender)
     (current-index (default-to u0 (map-get? last-index {agent-id: agent-id, client: caller})))
     (next-index (+ current-index u1))
     (auth-check (contract-call? .identity-registry is-authorized-or-owner caller agent-id))
@@ -147,7 +147,7 @@
   (feedback-hash (buff 32))
 )
   (let (
-    (caller contract-caller)
+    (caller tx-sender)
     (current-index (default-to u0 (map-get? last-index {agent-id: agent-id, client: caller})))
     (next-index (+ current-index u1))
     (approved-limit (default-to u0 (map-get? approved-clients {agent-id: agent-id, client: caller})))
@@ -213,7 +213,7 @@
   (signature (buff 65))
 )
   (let (
-    (caller contract-caller)
+    (caller tx-sender)
     (current-index (default-to u0 (map-get? last-index {agent-id: agent-id, client: caller})))
     (next-index (+ current-index u1))
   )
@@ -271,7 +271,7 @@
 
 (define-public (revoke-feedback (agent-id uint) (index uint))
   (let (
-    (caller contract-caller)
+    (caller tx-sender)
     (fb (unwrap! (map-get? feedback {agent-id: agent-id, client: caller, index: index}) ERR_FEEDBACK_NOT_FOUND))
   )
     ;; Verify index is valid (> 0)
@@ -304,7 +304,7 @@
   (response-hash (buff 32))
 )
   (let (
-    (responder contract-caller)
+    (responder tx-sender)
     (client-last-idx (default-to u0 (map-get? last-index {agent-id: agent-id, client: client})))
   )
     ;; Verify index is valid

--- a/contracts/validation-registry.clar
+++ b/contracts/validation-registry.clar
@@ -1,5 +1,5 @@
 ;; title: validation-registry
-;; version: 1.0.0
+;; version: 2.0.0
 ;; summary: ERC-8004 Validation Registry - Manages validation requests and responses for agents.
 ;; description: Allows agent owners to request validation from validators, who respond with scores.
 
@@ -49,9 +49,9 @@
   (request-hash (buff 32))
 )
   (let (
-    (caller contract-caller)
+    (caller tx-sender)
   )
-    ;; Check validator is not zero address (can't check for zero in Clarity, but can check it's not caller)
+    ;; Check validator is not the caller (prevents self-validation)
     (asserts! (not (is-eq validator caller)) ERR_INVALID_VALIDATOR)
     ;; Check caller is authorized (owner or approved operator)
     (asserts! (is-authorized agent-id caller) ERR_NOT_AUTHORIZED)
@@ -107,7 +107,7 @@
 )
   (let (
     (validation (unwrap! (map-get? validations {request-hash: request-hash}) ERR_VALIDATION_NOT_FOUND))
-    (caller contract-caller)
+    (caller tx-sender)
   )
     ;; Check caller is the validator
     (asserts! (is-eq caller (get validator validation)) ERR_NOT_AUTHORIZED)

--- a/tests/erc8004-integration.test.ts
+++ b/tests/erc8004-integration.test.ts
@@ -763,7 +763,13 @@ describe("ERC-8004 Integration: v2.0.0 NFT and Agent Wallet Features", () => {
     );
     expect(walletResult.result).toBeSome(Cl.principal(agentOwner));
 
-    // Set wallet via tx-sender path (client1 proves ownership)
+    // Approve client1 as operator, then set wallet via tx-sender path
+    simnet.callPublicFn(
+      "identity-registry",
+      "set-approval-for-all",
+      [uintCV(agentId), principalCV(client1), Cl.bool(true)],
+      agentOwner
+    );
     const directResult = simnet.callPublicFn(
       "identity-registry",
       "set-agent-wallet-direct",


### PR DESCRIPTION
## Summary

Security fixes from code review of v2.0.0 contracts:

- **tx-sender consistency**: Switch all 12 `contract-caller` call sites to `tx-sender` across all three contracts. Fixes self-feedback bypass where agent owners could route through any proxy contract to circumvent the guard. Improves proxy composability — owners/operators can use intermediary contracts without losing identity.
- **Wallet auth gap**: Add `is-authorized` check to `set-agent-wallet-direct`. Previously any address could call this to claim any agent's wallet with no ownership verification.
- **SIP-018 hash fix**: Identity registry's `hash-sip018-message` used a non-standard format (no prefix, no separate hashing). Fixed to match SIP-018 spec and the reputation registry's correct implementation: `SHA256(PREFIX || SHA256(domain) || SHA256(message))`.
- **Version headers**: Updated from 1.0.0 to 2.0.0 in all three contract file headers.

## Test plan

- [x] `clarinet check` passes (3 contracts, 0 errors)
- [x] `npm test` passes (126 tests, up from 125 — added unauthorized wallet test)
- [ ] Review tx-sender behavior with proxy contracts in `clarinet console`
- [ ] Verify SIP-018 signature generation matches off-chain tooling

🤖 Generated with [Claude Code](https://claude.com/claude-code)