### PR TITLE
chore: update package name to match project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "owner-agent-registry-tests",
+  "name": "erc-8004-stacks-contracts",
   "version": "1.0.0",
   "description": "Run unit tests on this project.",
   "type": "module",


### PR DESCRIPTION
## Summary
- Updates `package.json` name from legacy `owner-agent-registry-tests` to `erc-8004-stacks-contracts` to match the project and `Clarinet.toml`

## Test plan
- [x] `npm test` — 149 tests passing
- [x] `clarinet check` — 6 contracts checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)