### PR TITLE
docs: add mainnet and testnet deployed contract addresses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,27 @@ Three singleton registry contracts, deployed once per chain:
 - **Reputation Registry** — Client feedback with signed int values, WAD-normalized running totals
 - **Validation Registry** — Third-party validation requests with progressive responses
 
+### Deployed Contracts
+
+**Mainnet** — deployer: `SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD`
+
+| Contract ID | Type |
+|-------------|------|
+| `SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2` | Registry |
+| `SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.reputation-registry-v2` | Registry |
+| `SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.validation-registry-v2` | Registry |
+| `SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-trait-v2` | Trait |
+| `SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.reputation-registry-trait-v2` | Trait |
+| `SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.validation-registry-trait-v2` | Trait |
+
+**Testnet** — deployer: `ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18`
+
+| Contract ID | Type |
+|-------------|------|
+| `ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.identity-registry-v2` | Registry |
+| `ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.reputation-registry-v2` | Registry |
+| `ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.validation-registry-v2` | Registry |
+
 ## Identity Registry (`identity-registry-v2`)
 
 Agents are SIP-009 NFTs. Each agent gets a sequential uint ID, optional URI, key-value metadata, and an agent wallet (principal). Supports owner, operator (approval-for-all), and SIP-018 signature authorization.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,9 @@ Three singleton registry contracts, deployed once per chain:
 | `ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.identity-registry-v2` | Registry |
 | `ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.reputation-registry-v2` | Registry |
 | `ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.validation-registry-v2` | Registry |
+| `ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.identity-registry-trait-v2` | Trait |
+| `ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.reputation-registry-trait-v2` | Trait |
+| `ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.validation-registry-trait-v2` | Trait |
 
 ## Identity Registry (`identity-registry-v2`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ERC-8004 Stacks Contracts - Clarity smart contracts implementing the ERC-8004 agent identity/reputation/validation protocol for Stacks blockchain. Mirrors the [Solidity reference implementation](https://github.com/erc-8004/erc-8004-contracts).
 
-**Current Status**: All three registries ✅ complete with 149 tests passing. v2.0.0 spec-compliant. Deployed to testnet.
+**Current Status**: All three registries complete with 149 tests passing. v2.0.0 spec-compliant. Deployed to mainnet and testnet.
+
+**Mainnet deployer**: `SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD`
+**Testnet deployer**: `ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18`
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Cross-chain standard — same protocol on [Ethereum](https://github.com/erc-8004
 | `identity-registry-v2` | [view](https://explorer.hiro.so/txid/ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.identity-registry-v2?chain=testnet) |
 | `reputation-registry-v2` | [view](https://explorer.hiro.so/txid/ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.reputation-registry-v2?chain=testnet) |
 | `validation-registry-v2` | [view](https://explorer.hiro.so/txid/ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.validation-registry-v2?chain=testnet) |
+| `identity-registry-trait-v2` | [view](https://explorer.hiro.so/txid/ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.identity-registry-trait-v2?chain=testnet) |
+| `reputation-registry-trait-v2` | [view](https://explorer.hiro.so/txid/ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.reputation-registry-trait-v2?chain=testnet) |
+| `validation-registry-trait-v2` | [view](https://explorer.hiro.so/txid/ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.validation-registry-trait-v2?chain=testnet) |
 
 ## Contracts
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@ Clarity smart contracts implementing the [ERC-8004](https://eips.ethereum.org/EI
 
 Cross-chain standard — same protocol on [Ethereum](https://github.com/erc-8004/erc-8004-contracts) (Solidity), [Solana](https://github.com/Woody4618/s8004) (Rust), and Stacks (Clarity).
 
+## Deployed Contracts
+
+### Mainnet (`SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD`)
+
+| Contract | Explorer |
+|----------|----------|
+| `identity-registry-v2` | [view](https://explorer.hiro.so/txid/SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2?chain=mainnet) |
+| `reputation-registry-v2` | [view](https://explorer.hiro.so/txid/SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.reputation-registry-v2?chain=mainnet) |
+| `validation-registry-v2` | [view](https://explorer.hiro.so/txid/SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.validation-registry-v2?chain=mainnet) |
+| `identity-registry-trait-v2` | [view](https://explorer.hiro.so/txid/SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-trait-v2?chain=mainnet) |
+| `reputation-registry-trait-v2` | [view](https://explorer.hiro.so/txid/SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.reputation-registry-trait-v2?chain=mainnet) |
+| `validation-registry-trait-v2` | [view](https://explorer.hiro.so/txid/SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.validation-registry-trait-v2?chain=mainnet) |
+
+### Testnet (`ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18`)
+
+| Contract | Explorer |
+|----------|----------|
+| `identity-registry-v2` | [view](https://explorer.hiro.so/txid/ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.identity-registry-v2?chain=testnet) |
+| `reputation-registry-v2` | [view](https://explorer.hiro.so/txid/ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.reputation-registry-v2?chain=testnet) |
+| `validation-registry-v2` | [view](https://explorer.hiro.so/txid/ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18.validation-registry-v2?chain=testnet) |
+
 ## Contracts
 
 | Contract | Purpose |


### PR DESCRIPTION
## Summary
- Added deployed contract addresses and explorer links for mainnet (`SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD`) and testnet (`ST3YT0XW92E6T2FE59B2G5N2WNNFSBZ6MZKQS5D18`) to README.md, AGENTS.md, and CLAUDE.md
- All 6 contracts: 3 registries + 3 traits with Hiro explorer links

## Test plan
- [x] Verify explorer links resolve correctly for mainnet contracts
- [x] Verify explorer links resolve correctly for testnet contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)