### PR TITLE
feat: add reverse lookup map (agent-id-by-owner) to identity-registry-v3

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -23,6 +23,16 @@ path = 'contracts/validation-registry-v2.clar'
 clarity_version = 4
 epoch = 'latest'
 
+[contracts.identity-registry-v3]
+path = 'contracts/identity-registry-v3.clar'
+clarity_version = 4
+epoch = 'latest'
+
+[contracts.identity-registry-trait-v3]
+path = 'contracts/traits/identity-registry-trait-v3.clar'
+clarity_version = 4
+epoch = 'latest'
+
 [contracts.identity-registry-trait-v2]
 path = 'contracts/traits/identity-registry-trait-v2.clar'
 clarity_version = 4

--- a/contracts/identity-registry-v3.clar
+++ b/contracts/identity-registry-v3.clar
@@ -36,7 +36,6 @@
 
 ;; traits
 (impl-trait .identity-registry-trait-v3.identity-registry-trait)
-(use-trait nft-trait 'SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait.nft-trait)
 ;;
 
 ;; token definitions

--- a/contracts/identity-registry-v3.clar
+++ b/contracts/identity-registry-v3.clar
@@ -198,8 +198,11 @@
       (asserts! (not (is-eq tx-sender current-wallet)) ERR_WALLET_ALREADY_SET)
       true
     )
-    ;; Set new wallet
+    ;; Clear old wallet and reverse lookup
+    (clear-agent-wallet agent-id)
+    ;; Set new wallet and reverse lookup
     (map-set agent-wallets agent-id tx-sender)
+    (map-set agent-id-by-owner tx-sender agent-id)
     (print {
       notification: "MetadataSet",
       payload: {
@@ -246,8 +249,11 @@
     )
       ;; Verify signature is from new-wallet
       (asserts! (is-eq recovered-principal new-wallet) ERR_INVALID_SIGNATURE)
-      ;; Set new wallet
+      ;; Clear old wallet and reverse lookup
+      (clear-agent-wallet agent-id)
+      ;; Set new wallet and reverse lookup
       (map-set agent-wallets agent-id new-wallet)
+      (map-set agent-id-by-owner new-wallet agent-id)
       (print {
         notification: "MetadataSet",
         payload: {

--- a/contracts/identity-registry-v3.clar
+++ b/contracts/identity-registry-v3.clar
@@ -1,0 +1,434 @@
+;; title: identity-registry
+;; version: 3.0.0
+;; summary: ERC-8004 Identity Registry - Registers agent identities with sequential IDs, URIs, and metadata.
+;; description: Compliant with ERC-8004 spec. Owner or approved operators can update URI/metadata. Single deployment per chain.
+;; auth: All authorization checks use tx-sender. Contract principals acting as owners/operators must use as-contract.
+;;
+;; ERC-8004 Spec Compliance
+;; ========================
+;;
+;; Spec Function/Feature              | Implementation                    | Notes
+;; ------------------------------------|-----------------------------------|------
+;; ERC-721 NFT standard                | SIP-009 NFT (define-non-fungible-token) | Stacks equivalent
+;; register()                          | register                          | Exact match
+;; register(agentURI)                  | register-with-uri                 | Exact match
+;; register(agentURI, metadata[])      | register-full                     | Exact match
+;; setAgentURI(agentId, newURI)        | set-agent-uri                     | Exact match
+;; getMetadata(agentId, key)           | get-metadata                      | Returns optional (Clarity convention)
+;; setMetadata(agentId, key, value)    | set-metadata                      | Exact match
+;; agentWallet reserved key            | ERR_RESERVED_KEY in set-metadata + register-full | Exact match
+;; agentWallet auto-set on register    | map-set agent-wallets in register | Exact match
+;; setAgentWallet (EIP-712 signature)  | set-agent-wallet-signed (SIP-018) | Stacks equivalent of EIP-712
+;; (no EVM equivalent)                 | set-agent-wallet-direct           | Stacks enhancement: tx-sender path
+;; getAgentWallet(agentId)             | get-agent-wallet                  | Returns optional (Clarity convention)
+;; unsetAgentWallet(agentId)           | unset-agent-wallet                | Exact match
+;; Transfer clears agentWallet         | map-delete in transfer            | Exact match
+;; isAuthorizedOrOwner                 | is-authorized-or-owner            | Exact match (reverts if no agent)
+;; Registered event                    | SIP-019 print                     | Stacks equivalent of EVM event
+;; MetadataSet event                   | SIP-019 print (per-entry in fold) | Stacks equivalent of EVM event
+;; URIUpdated event                    | SIP-019 print                     | Stacks equivalent of EVM event
+;; Transfer event                      | SIP-019 print + native NFT event  | Stacks equivalent of EVM event
+;; ERC-721 getTokenURI                 | get-token-uri (SIP-009)           | string-utf8 512 (wider than ERC-721)
+;; ERC-721 ownerOf                     | get-owner / owner-of              | Exact match
+;; ERC-721 transferFrom                | transfer                          | SIP-009 pattern (sender must be tx-sender)
+;; approve / setApprovalForAll         | set-approval-for-all              | Per-agent operator approval
+;; getApproved / isApprovedForAll      | is-approved-for-all               | Exact match
+
+;; traits
+(impl-trait .identity-registry-trait-v3.identity-registry-trait)
+(use-trait nft-trait 'SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait.nft-trait)
+;;
+
+;; token definitions
+(define-non-fungible-token agent-identity uint)
+;;
+
+;; constants
+(define-constant ERR_NOT_AUTHORIZED (err u1000))
+(define-constant ERR_AGENT_NOT_FOUND (err u1001))
+(define-constant ERR_AGENT_ALREADY_EXISTS (err u1002))
+(define-constant ERR_METADATA_SET_FAILED (err u1003))
+(define-constant ERR_RESERVED_KEY (err u1004))
+(define-constant ERR_INVALID_SENDER (err u1005))
+(define-constant ERR_WALLET_ALREADY_SET (err u1006))
+(define-constant ERR_EXPIRED_SIGNATURE (err u1007))
+(define-constant ERR_INVALID_SIGNATURE (err u1008))
+(define-constant MAX_URI_LEN u512)
+(define-constant MAX_KEY_LEN u128)
+(define-constant MAX_VALUE_LEN u512)
+(define-constant MAX_METADATA_ENTRIES u10)
+(define-constant MAX_DEADLINE_DELAY u1500) ;; ~5 min at 200s blocks
+(define-constant RESERVED_KEY_AGENT_WALLET u"agentWallet")
+(define-constant SIP018_PREFIX 0x534950303138)
+(define-constant DOMAIN_NAME "identity-registry")
+(define-constant DOMAIN_VERSION "3.0.0")
+(define-constant VERSION u"3.0.0")
+;;
+
+;; data vars
+(define-data-var next-agent-id uint u0)
+;;
+
+;; data maps
+(define-map uris {agent-id: uint} (string-utf8 512))
+(define-map metadata {agent-id: uint, key: (string-utf8 128)} (buff 512))
+(define-map approvals {agent-id: uint, operator: principal} bool)
+(define-map agent-wallets {agent-id: uint} principal)
+(define-map agent-id-by-owner principal uint)
+;;
+
+;; public functions
+
+(define-public (register)
+  (register-with-uri u"")
+)
+
+(define-public (register-with-uri (token-uri (string-utf8 512)))
+  (register-full token-uri (list))
+)
+
+(define-public (register-full
+  (token-uri (string-utf8 512))
+  (metadata-entries (list 10 {key: (string-utf8 128), value: (buff 512)}))
+)
+  (let (
+    (agent-id (var-get next-agent-id))
+    (owner tx-sender)
+    (updated-next (+ agent-id u1))
+  )
+    ;; Atomic update
+    (var-set next-agent-id updated-next)
+    (try! (nft-mint? agent-identity agent-id owner))
+    (asserts! (map-insert uris {agent-id: agent-id} token-uri) ERR_AGENT_ALREADY_EXISTS)
+    ;; Auto-set agent-wallet to owner
+    (map-set agent-wallets {agent-id: agent-id} owner)
+    ;; Reverse lookup: owner -> agent-id (last-write-wins for multiple registrations)
+    (map-set agent-id-by-owner owner agent-id)
+    (let (
+      (fold-result (fold metadata-fold-entry metadata-entries
+        {agent-id: agent-id, success: true, reserved-key-found: false}
+      ))
+    )
+      (asserts! (not (get reserved-key-found fold-result)) ERR_RESERVED_KEY)
+      (asserts! (get success fold-result) ERR_METADATA_SET_FAILED)
+      true
+    )
+    (print {
+      notification: "identity-registry/Registered",
+      payload: {
+        agent-id: agent-id,
+        owner: owner,
+        token-uri: token-uri,
+        metadata-count: (len metadata-entries)
+      }
+    })
+    (print {
+      notification: "identity-registry/MetadataSet",
+      payload: {
+        agent-id: agent-id,
+        key: RESERVED_KEY_AGENT_WALLET,
+        value-len: u20
+      }
+    })
+    (ok agent-id)
+  )
+)
+
+(define-public (set-agent-uri (agent-id uint) (new-uri (string-utf8 512)))
+  (begin 
+    (asserts! (is-authorized agent-id tx-sender) ERR_NOT_AUTHORIZED)
+    (map-set uris {agent-id: agent-id} new-uri)
+    (print {
+      notification: "identity-registry/UriUpdated",
+      payload: {
+        agent-id: agent-id,
+        new-uri: new-uri,
+        updated-by: tx-sender
+      }
+    })
+    (ok true)
+  )
+)
+
+(define-public (set-metadata (agent-id uint) (key (string-utf8 128)) (value (buff 512)))
+  (begin
+    (asserts! (is-authorized agent-id tx-sender) ERR_NOT_AUTHORIZED)
+    (asserts! (not (is-eq key RESERVED_KEY_AGENT_WALLET)) ERR_RESERVED_KEY)
+    (map-set metadata {agent-id: agent-id, key: key} value)
+    (print {
+      notification: "identity-registry/MetadataSet",
+      payload: {
+        agent-id: agent-id,
+        key: key,
+        value-len: (len value)
+      }
+    })
+    (ok true)
+  )
+)
+
+(define-public (set-approval-for-all (agent-id uint) (operator principal) (approved bool))
+  (let (
+    (owner (unwrap! (nft-get-owner? agent-identity agent-id) ERR_AGENT_NOT_FOUND))
+  )
+    (asserts! (is-eq tx-sender owner) ERR_NOT_AUTHORIZED)
+    (map-set approvals {agent-id: agent-id, operator: operator} approved)
+    (print {
+      notification: "identity-registry/ApprovalForAll",
+      payload: {
+        agent-id: agent-id,
+        operator: operator,
+        approved: approved
+      }
+    })
+    (ok true)
+  )
+)
+
+(define-public (set-agent-wallet-direct (agent-id uint))
+  (let (
+    (current-wallet-opt (map-get? agent-wallets {agent-id: agent-id}))
+  )
+    ;; Verify agent exists
+    (unwrap! (nft-get-owner? agent-identity agent-id) ERR_AGENT_NOT_FOUND)
+    ;; Check caller is authorized (owner or approved operator)
+    (asserts! (is-authorized agent-id tx-sender) ERR_NOT_AUTHORIZED)
+    ;; Check caller is not already the wallet
+    (match current-wallet-opt current-wallet
+      (asserts! (not (is-eq tx-sender current-wallet)) ERR_WALLET_ALREADY_SET)
+      true
+    )
+    ;; Set new wallet
+    (map-set agent-wallets {agent-id: agent-id} tx-sender)
+    (print {
+      notification: "identity-registry/MetadataSet",
+      payload: {
+        agent-id: agent-id,
+        key: RESERVED_KEY_AGENT_WALLET,
+        value-len: u20
+      }
+    })
+    (ok true)
+  )
+)
+
+(define-public (set-agent-wallet-signed
+  (agent-id uint)
+  (new-wallet principal)
+  (deadline uint)
+  (signature (buff 65))
+)
+  (let (
+    (owner (unwrap! (nft-get-owner? agent-identity agent-id) ERR_AGENT_NOT_FOUND))
+    (current-height stacks-block-height)
+  )
+    ;; Authorization check
+    (asserts! (is-authorized agent-id tx-sender) ERR_NOT_AUTHORIZED)
+    ;; Deadline checks
+    (asserts! (<= current-height deadline) ERR_EXPIRED_SIGNATURE)
+    (asserts! (<= deadline (+ current-height MAX_DEADLINE_DELAY)) ERR_EXPIRED_SIGNATURE)
+    ;; Build SIP-018 structured data
+    (let (
+      (domain {
+        name: DOMAIN_NAME,
+        version: DOMAIN_VERSION,
+        chain-id: chain-id
+      })
+      (message {
+        agent-id: agent-id,
+        new-wallet: new-wallet,
+        owner: owner,
+        deadline: deadline
+      })
+      (msg-hash (hash-sip018-message domain message))
+      (recovered-key (unwrap! (secp256k1-recover? msg-hash signature) ERR_INVALID_SIGNATURE))
+      (recovered-principal (unwrap! (principal-of? recovered-key) ERR_INVALID_SIGNATURE))
+    )
+      ;; Verify signature is from new-wallet
+      (asserts! (is-eq recovered-principal new-wallet) ERR_INVALID_SIGNATURE)
+      ;; Set new wallet
+      (map-set agent-wallets {agent-id: agent-id} new-wallet)
+      (print {
+        notification: "identity-registry/MetadataSet",
+        payload: {
+          agent-id: agent-id,
+          key: RESERVED_KEY_AGENT_WALLET,
+          value-len: u20
+        }
+      })
+      (ok true)
+    )
+  )
+)
+
+(define-public (unset-agent-wallet (agent-id uint))
+  (let (
+    (owner (unwrap! (nft-get-owner? agent-identity agent-id) ERR_AGENT_NOT_FOUND))
+  )
+    (asserts! (is-authorized agent-id tx-sender) ERR_NOT_AUTHORIZED)
+    (map-delete agent-wallets {agent-id: agent-id})
+    (print {
+      notification: "identity-registry/MetadataSet",
+      payload: {
+        agent-id: agent-id,
+        key: RESERVED_KEY_AGENT_WALLET,
+        value-len: u0
+      }
+    })
+    (ok true)
+  )
+)
+
+(define-public (transfer (token-id uint) (sender principal) (recipient principal))
+  (begin
+    (asserts! (is-eq tx-sender sender) ERR_INVALID_SENDER)
+    (let ((actual-owner (unwrap! (nft-get-owner? agent-identity token-id) ERR_AGENT_NOT_FOUND)))
+      (asserts! (is-eq sender actual-owner) ERR_NOT_AUTHORIZED)
+      ;; Clear agent wallet before transfer
+      (map-delete agent-wallets {agent-id: token-id})
+      ;; Update reverse lookup: remove sender, set recipient
+      (map-delete agent-id-by-owner sender)
+      (map-set agent-id-by-owner recipient token-id)
+      (print {
+        notification: "identity-registry/MetadataSet",
+        payload: {
+          agent-id: token-id,
+          key: RESERVED_KEY_AGENT_WALLET,
+          value-len: u0
+        }
+      })
+      (try! (nft-transfer? agent-identity token-id sender recipient))
+      (print {
+        notification: "identity-registry/Transfer",
+        payload: {
+          token-id: token-id,
+          sender: sender,
+          recipient: recipient
+        }
+      })
+      (ok true)
+    )
+  )
+)
+;;
+
+;; read only functions
+
+;; Legacy alias for backward compatibility
+(define-read-only (owner-of (agent-id uint))
+  (nft-get-owner? agent-identity agent-id)
+)
+
+(define-read-only (get-uri (agent-id uint))
+  (map-get? uris {agent-id: agent-id})
+)
+
+(define-read-only (get-metadata (agent-id uint) (key (string-utf8 128)))
+  (map-get? metadata {agent-id: agent-id, key: key})
+)
+
+(define-read-only (is-approved-for-all (agent-id uint) (operator principal))
+  (default-to false (map-get? approvals {agent-id: agent-id, operator: operator}))
+)
+
+(define-read-only (get-agent-id-by-owner (owner principal))
+  (map-get? agent-id-by-owner owner)
+)
+
+(define-read-only (get-version)
+  VERSION
+)
+
+(define-read-only (get-agent-wallet (agent-id uint))
+  (map-get? agent-wallets {agent-id: agent-id})
+)
+
+(define-read-only (is-authorized-or-owner (spender principal) (agent-id uint))
+  (let (
+    (owner (unwrap! (nft-get-owner? agent-identity agent-id) ERR_AGENT_NOT_FOUND))
+  )
+    (ok (or
+      (is-eq spender owner)
+      (is-approved-for-all agent-id spender)
+    ))
+  )
+)
+
+;; SIP-009 trait functions
+
+(define-read-only (get-last-token-id)
+  (let ((current-id (var-get next-agent-id)))
+    (if (is-eq current-id u0)
+      ERR_AGENT_NOT_FOUND
+      (ok (- current-id u1))
+    )
+  )
+)
+
+(define-read-only (get-token-uri (token-id uint))
+  (ok (map-get? uris {agent-id: token-id}))
+)
+
+(define-read-only (get-owner (token-id uint))
+  (ok (nft-get-owner? agent-identity token-id))
+)
+;;
+
+;; private functions
+
+(define-private (metadata-fold-entry
+  (entry {key: (string-utf8 128), value: (buff 512)})
+  (prior-acc {agent-id: uint, success: bool, reserved-key-found: bool})
+)
+  (if (not (get success prior-acc))
+    prior-acc
+    (let (
+      (aid (get agent-id prior-acc))
+    )
+      (if (is-eq (get key entry) RESERVED_KEY_AGENT_WALLET)
+        {agent-id: aid, success: false, reserved-key-found: true}
+        (let (
+          (k (get key entry))
+          (v (get value entry))
+        )
+          (map-set metadata {agent-id: aid, key: k} v)
+          (print {
+            notification: "identity-registry/MetadataSet",
+            payload: {
+              agent-id: aid,
+              key: k,
+              value-len: (len v)
+            }
+          })
+          {agent-id: aid, success: true, reserved-key-found: false}
+        )
+      )
+    )
+  )
+)
+
+(define-private (is-authorized (agent-id uint) (caller principal))
+  (let (
+    (owner-opt (nft-get-owner? agent-identity agent-id))
+  )
+    (match owner-opt owner
+      (or
+        (is-eq caller owner)
+        (is-approved-for-all agent-id caller)
+      )
+      false
+    )
+  )
+)
+
+(define-private (hash-sip018-message
+  (domain {name: (string-ascii 64), version: (string-ascii 64), chain-id: uint})
+  (message {agent-id: uint, new-wallet: principal, owner: principal, deadline: uint})
+)
+  (let (
+    (domain-hash (sha256 (unwrap-panic (to-consensus-buff? domain))))
+    (structured-data-hash (sha256 (unwrap-panic (to-consensus-buff? message))))
+  )
+    (sha256 (concat SIP018_PREFIX (concat domain-hash structured-data-hash)))
+  )
+)

--- a/contracts/traits/identity-registry-trait-v3.clar
+++ b/contracts/traits/identity-registry-trait-v3.clar
@@ -1,0 +1,36 @@
+;; title: identity-registry-trait
+;; version: 3.0.0
+;; summary: Trait definition for ERC-8004 Identity Registry
+;; description: Defines the interface for identity registry contracts. Includes all public state-changing functions and response-wrapped read-only functions (SIP-009 + is-authorized-or-owner).
+
+(define-trait identity-registry-trait
+  (
+    ;; Registration functions
+    (register () (response uint uint))
+    (register-with-uri ((string-utf8 512)) (response uint uint))
+    (register-full ((string-utf8 512) (list 10 {key: (string-utf8 128), value: (buff 512)})) (response uint uint))
+
+    ;; Metadata management
+    (set-agent-uri (uint (string-utf8 512)) (response bool uint))
+    (set-metadata (uint (string-utf8 128) (buff 512)) (response bool uint))
+
+    ;; Approval management
+    (set-approval-for-all (uint principal bool) (response bool uint))
+
+    ;; Agent wallet management
+    (set-agent-wallet-direct (uint) (response bool uint))
+    (set-agent-wallet-signed (uint principal uint (buff 65)) (response bool uint))
+    (unset-agent-wallet (uint) (response bool uint))
+
+    ;; NFT transfer (SIP-009)
+    (transfer (uint principal principal) (response bool uint))
+
+    ;; SIP-009 trait functions (response-wrapped read-only)
+    (get-last-token-id () (response uint uint))
+    (get-token-uri (uint) (response (optional (string-utf8 512)) uint))
+    (get-owner (uint) (response (optional principal) uint))
+
+    ;; Authorization helper (response-wrapped read-only)
+    (is-authorized-or-owner (principal uint) (response bool uint))
+  )
+)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "owner-agent-registry-tests",
+  "name": "erc-8004-stacks-contracts",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "owner-agent-registry-tests",
+      "name": "erc-8004-stacks-contracts",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/tests/identity-registry-v3.test.ts
+++ b/tests/identity-registry-v3.test.ts
@@ -108,6 +108,33 @@ describe("identity-registry-v3 reverse lookup", () => {
     });
   });
 
+  describe("unset-agent-wallet clears reverse lookup", () => {
+    it("clears reverse lookup when wallet is unset", () => {
+      simnet.callPublicFn(CONTRACT, "register", [], wallet1);
+
+      // Verify reverse lookup is set
+      let result = simnet.callReadOnlyFn(
+        CONTRACT,
+        "get-agent-id-by-owner",
+        [Cl.principal(wallet1)],
+        wallet1
+      );
+      expect(result.result).toBeSome(uintCV(0n));
+
+      // Unset agent wallet
+      simnet.callPublicFn(CONTRACT, "unset-agent-wallet", [Cl.uint(0)], wallet1);
+
+      // Reverse lookup should be cleared
+      result = simnet.callReadOnlyFn(
+        CONTRACT,
+        "get-agent-id-by-owner",
+        [Cl.principal(wallet1)],
+        wallet1
+      );
+      expect(result.result).toBeNone();
+    });
+  });
+
   describe("transfer updates reverse lookup", () => {
     it("updates reverse lookup on transfer", () => {
       // wallet1 registers

--- a/tests/identity-registry-v3.test.ts
+++ b/tests/identity-registry-v3.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Cl, uintCV } from "@stacks/transactions";
+
+const CONTRACT = "identity-registry-v3";
+
+describe("identity-registry-v3 reverse lookup", () => {
+  const accounts = simnet.getAccounts();
+  const wallet1 = accounts.get("wallet_1")!;
+  const wallet2 = accounts.get("wallet_2")!;
+
+  describe("get-agent-id-by-owner", () => {
+    it("returns none for unregistered owner", () => {
+      const { result } = simnet.callReadOnlyFn(
+        CONTRACT,
+        "get-agent-id-by-owner",
+        [Cl.principal(wallet1)],
+        wallet1
+      );
+      expect(result).toBeNone();
+    });
+
+    it("returns agent-id after registration", () => {
+      simnet.callPublicFn(CONTRACT, "register", [], wallet1);
+      const { result } = simnet.callReadOnlyFn(
+        CONTRACT,
+        "get-agent-id-by-owner",
+        [Cl.principal(wallet1)],
+        wallet1
+      );
+      expect(result).toBeSome(uintCV(0n));
+    });
+
+    it("returns agent-id after register-with-uri", () => {
+      simnet.callPublicFn(
+        CONTRACT,
+        "register-with-uri",
+        [Cl.stringUtf8("https://example.com/agent")],
+        wallet1
+      );
+      const { result } = simnet.callReadOnlyFn(
+        CONTRACT,
+        "get-agent-id-by-owner",
+        [Cl.principal(wallet1)],
+        wallet1
+      );
+      expect(result).toBeSome(uintCV(0n));
+    });
+
+    it("returns agent-id after register-full", () => {
+      simnet.callPublicFn(
+        CONTRACT,
+        "register-full",
+        [
+          Cl.stringUtf8("https://example.com/agent"),
+          Cl.list([
+            Cl.tuple({
+              key: Cl.stringUtf8("name"),
+              value: Cl.buffer(Buffer.from("test-agent")),
+            }),
+          ]),
+        ],
+        wallet1
+      );
+      const { result } = simnet.callReadOnlyFn(
+        CONTRACT,
+        "get-agent-id-by-owner",
+        [Cl.principal(wallet1)],
+        wallet1
+      );
+      expect(result).toBeSome(uintCV(0n));
+    });
+
+    it("updates to latest agent-id on multiple registrations", () => {
+      // First registration
+      simnet.callPublicFn(CONTRACT, "register", [], wallet1);
+      // Second registration by same owner
+      simnet.callPublicFn(CONTRACT, "register", [], wallet1);
+
+      const { result } = simnet.callReadOnlyFn(
+        CONTRACT,
+        "get-agent-id-by-owner",
+        [Cl.principal(wallet1)],
+        wallet1
+      );
+      // Should be the latest (agent-id 1)
+      expect(result).toBeSome(uintCV(1n));
+    });
+
+    it("tracks different owners independently", () => {
+      simnet.callPublicFn(CONTRACT, "register", [], wallet1);
+      simnet.callPublicFn(CONTRACT, "register", [], wallet2);
+
+      const result1 = simnet.callReadOnlyFn(
+        CONTRACT,
+        "get-agent-id-by-owner",
+        [Cl.principal(wallet1)],
+        wallet1
+      );
+      const result2 = simnet.callReadOnlyFn(
+        CONTRACT,
+        "get-agent-id-by-owner",
+        [Cl.principal(wallet2)],
+        wallet2
+      );
+
+      expect(result1.result).toBeSome(uintCV(0n));
+      expect(result2.result).toBeSome(uintCV(1n));
+    });
+  });
+
+  describe("transfer updates reverse lookup", () => {
+    it("updates reverse lookup on transfer", () => {
+      // wallet1 registers
+      simnet.callPublicFn(CONTRACT, "register", [], wallet1);
+
+      // Transfer from wallet1 to wallet2
+      simnet.callPublicFn(
+        CONTRACT,
+        "transfer",
+        [Cl.uint(0), Cl.principal(wallet1), Cl.principal(wallet2)],
+        wallet1
+      );
+
+      // wallet1 should no longer have an agent
+      const result1 = simnet.callReadOnlyFn(
+        CONTRACT,
+        "get-agent-id-by-owner",
+        [Cl.principal(wallet1)],
+        wallet1
+      );
+      expect(result1.result).toBeNone();
+
+      // wallet2 should now own agent 0
+      const result2 = simnet.callReadOnlyFn(
+        CONTRACT,
+        "get-agent-id-by-owner",
+        [Cl.principal(wallet2)],
+        wallet2
+      );
+      expect(result2.result).toBeSome(uintCV(0n));
+    });
+
+    it("preserves other agents when transferring one", () => {
+      // Both wallets register
+      simnet.callPublicFn(CONTRACT, "register", [], wallet1);
+      simnet.callPublicFn(CONTRACT, "register", [], wallet2);
+
+      // wallet2 transfers agent 1 to wallet1
+      simnet.callPublicFn(
+        CONTRACT,
+        "transfer",
+        [Cl.uint(1), Cl.principal(wallet2), Cl.principal(wallet1)],
+        wallet2
+      );
+
+      // wallet1's reverse lookup should now point to agent 1 (last-write-wins)
+      const result1 = simnet.callReadOnlyFn(
+        CONTRACT,
+        "get-agent-id-by-owner",
+        [Cl.principal(wallet1)],
+        wallet1
+      );
+      expect(result1.result).toBeSome(uintCV(1n));
+
+      // wallet2's reverse lookup should be cleared
+      const result2 = simnet.callReadOnlyFn(
+        CONTRACT,
+        "get-agent-id-by-owner",
+        [Cl.principal(wallet2)],
+        wallet2
+      );
+      expect(result2.result).toBeNone();
+    });
+  });
+});


### PR DESCRIPTION
Closes #17

## Context

Every flow that starts with an address and needs the agent-id currently has no on-chain way to do the lookup. This adds an O(1) reverse lookup.

## Changes

### `contracts/identity-registry-v3.clar`
- New `(define-map agent-id-by-owner principal uint)` — reverse lookup from wallet to agent-id
- `(define-map agent-wallets {agent-id: uint} principal)` simplified to `(define-map agent-wallets uint principal)`
- New `clear-agent-wallet` private function — clears both `agent-wallets` and `agent-id-by-owner` atomically
- `register-full`: sets both forward and reverse lookup on registration
- `transfer`: calls `clear-agent-wallet` (clears sender), sets recipient reverse lookup
- `unset-agent-wallet`: delegates to `clear-agent-wallet`
- `set-agent-wallet-direct`: clears old wallet mapping fully, sets both maps for new wallet
- `set-agent-wallet-signed`: same — clears old, sets both maps for new wallet
- New `(define-read-only (get-agent-id-by-owner (owner principal)))` returns `(optional uint)`
- Notification strings shortened (e.g. `"Registered"` instead of `"identity-registry/Registered"`)
- Version bumped to 3.0.0

### Design decisions
- **Last-write-wins**: If an owner registers multiple agents, the map stores the latest agent-id
- **1:1 mapping maintained**: `clear-agent-wallet` ensures both maps stay in sync across all code paths (unset, transfer, set-direct, set-signed)
- **Transfer-aware**: On transfer, sender's entries cleared via `clear-agent-wallet`, recipient reverse lookup set
- **Idempotent clear**: Calling `unset-agent-wallet` when already unset does not error

### Tests (`tests/identity-registry-v3.test.ts`)
13 tests covering:
- Returns none for unregistered owner
- Returns agent-id after register / register-with-uri / register-full
- Updates to latest agent-id on multiple registrations
- Tracks different owners independently
- `clear-agent-wallet` clears both `agent-wallets` and `agent-id-by-owner`
- Idempotent unset (calling twice doesn't error)
- Re-establishes both maps after `set-agent-wallet-direct`
- `set-agent-wallet-direct` clears old wallet reverse lookup when operator sets new wallet
- `set-agent-wallet-direct` works when no prior wallet exists
- Transfer clears agent-wallet + sender reverse lookup, sets recipient reverse lookup
- Transfer preserves other agents' mappings

## v2 → v3 diff

<details>
<summary>Full contract diff (identity-registry-v2.clar → identity-registry-v3.clar)</summary>

```diff
--- contracts/identity-registry-v2.clar	2026-02-14 07:23:33.294472241 +0000
+++ contracts/identity-registry-v3.clar	2026-02-16 13:49:34.964764133 +0000
@@ -1,5 +1,5 @@
 ;; title: identity-registry
-;; version: 2.0.0
+;; version: 3.0.0
 ;; summary: ERC-8004 Identity Registry - Registers agent identities with sequential IDs, URIs, and metadata.
 ;; description: Compliant with ERC-8004 spec. Owner or approved operators can update URI/metadata. Single deployment per chain.
 ;; auth: All authorization checks use tx-sender. Contract principals acting as owners/operators must use as-contract.
@@ -35,7 +35,7 @@
 ;; getApproved / isApprovedForAll      | is-approved-for-all               | Exact match
 
 ;; traits
-(impl-trait .identity-registry-trait-v2.identity-registry-trait)
+(impl-trait .identity-registry-trait-v3.identity-registry-trait)
 (use-trait nft-trait 'SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait.nft-trait)
 ;;
 
@@ -61,8 +61,8 @@
 (define-constant RESERVED_KEY_AGENT_WALLET u"agentWallet")
 (define-constant SIP018_PREFIX 0x534950303138)
 (define-constant DOMAIN_NAME "identity-registry")
-(define-constant DOMAIN_VERSION "2.0.0")
-(define-constant VERSION u"2.0.0")
+(define-constant DOMAIN_VERSION "3.0.0")
+(define-constant VERSION u"3.0.0")
 ;;
 
 ;; data vars
@@ -73,7 +73,8 @@
 (define-map uris {agent-id: uint} (string-utf8 512))
 (define-map metadata {agent-id: uint, key: (string-utf8 128)} (buff 512))
 (define-map approvals {agent-id: uint, operator: principal} bool)
-(define-map agent-wallets {agent-id: uint} principal)
+(define-map agent-wallets uint principal)
+(define-map agent-id-by-owner principal uint)
 ;;
 
 ;; public functions
@@ -100,7 +101,9 @@
     (try! (nft-mint? agent-identity agent-id owner))
     (asserts! (map-insert uris {agent-id: agent-id} token-uri) ERR_AGENT_ALREADY_EXISTS)
     ;; Auto-set agent-wallet to owner
-    (map-set agent-wallets {agent-id: agent-id} owner)
+    (map-set agent-wallets agent-id owner)
+    ;; Reverse lookup: owner -> agent-id (last-write-wins for multiple registrations)
+    (map-set agent-id-by-owner owner agent-id)
     (let (
       (fold-result (fold metadata-fold-entry metadata-entries
         {agent-id: agent-id, success: true, reserved-key-found: false}
@@ -111,7 +114,7 @@
       true
     )
     (print {
-      notification: "identity-registry/Registered",
+      notification: "Registered",
       payload: {
         agent-id: agent-id,
         owner: owner,
@@ -120,7 +123,7 @@
       }
     })
     (print {
-      notification: "identity-registry/MetadataSet",
+      notification: "MetadataSet",
       payload: {
         agent-id: agent-id,
         key: RESERVED_KEY_AGENT_WALLET,
@@ -136,7 +139,7 @@
     (asserts! (is-authorized agent-id tx-sender) ERR_NOT_AUTHORIZED)
     (map-set uris {agent-id: agent-id} new-uri)
     (print {
-      notification: "identity-registry/UriUpdated",
+      notification: "UriUpdated",
       payload: {
         agent-id: agent-id,
         new-uri: new-uri,
@@ -153,7 +156,7 @@
     (asserts! (not (is-eq key RESERVED_KEY_AGENT_WALLET)) ERR_RESERVED_KEY)
     (map-set metadata {agent-id: agent-id, key: key} value)
     (print {
-      notification: "identity-registry/MetadataSet",
+      notification: "MetadataSet",
       payload: {
         agent-id: agent-id,
         key: key,
@@ -171,7 +174,7 @@
     (asserts! (is-eq tx-sender owner) ERR_NOT_AUTHORIZED)
     (map-set approvals {agent-id: agent-id, operator: operator} approved)
     (print {
-      notification: "identity-registry/ApprovalForAll",
+      notification: "ApprovalForAll",
       payload: {
         agent-id: agent-id,
         operator: operator,
@@ -184,7 +187,7 @@
 
 (define-public (set-agent-wallet-direct (agent-id uint))
   (let (
-    (current-wallet-opt (map-get? agent-wallets {agent-id: agent-id}))
+    (current-wallet-opt (map-get? agent-wallets agent-id))
   )
     ;; Verify agent exists
     (unwrap! (nft-get-owner? agent-identity agent-id) ERR_AGENT_NOT_FOUND)
@@ -195,10 +198,13 @@
       (asserts! (not (is-eq tx-sender current-wallet)) ERR_WALLET_ALREADY_SET)
       true
     )
-    ;; Set new wallet
-    (map-set agent-wallets {agent-id: agent-id} tx-sender)
+    ;; Clear old wallet and reverse lookup
+    (clear-agent-wallet agent-id)
+    ;; Set new wallet and reverse lookup
+    (map-set agent-wallets agent-id tx-sender)
+    (map-set agent-id-by-owner tx-sender agent-id)
     (print {
-      notification: "identity-registry/MetadataSet",
+      notification: "MetadataSet",
       payload: {
         agent-id: agent-id,
         key: RESERVED_KEY_AGENT_WALLET,
@@ -243,10 +249,13 @@
     )
       ;; Verify signature is from new-wallet
       (asserts! (is-eq recovered-principal new-wallet) ERR_INVALID_SIGNATURE)
-      ;; Set new wallet
-      (map-set agent-wallets {agent-id: agent-id} new-wallet)
+      ;; Clear old wallet and reverse lookup
+      (clear-agent-wallet agent-id)
+      ;; Set new wallet and reverse lookup
+      (map-set agent-wallets agent-id new-wallet)
+      (map-set agent-id-by-owner new-wallet agent-id)
       (print {
-        notification: "identity-registry/MetadataSet",
+        notification: "MetadataSet",
         payload: {
           agent-id: agent-id,
           key: RESERVED_KEY_AGENT_WALLET,
@@ -259,19 +268,9 @@
 )
 
 (define-public (unset-agent-wallet (agent-id uint))
-  (let (
-    (owner (unwrap! (nft-get-owner? agent-identity agent-id) ERR_AGENT_NOT_FOUND))
-  )
+  (begin
     (asserts! (is-authorized agent-id tx-sender) ERR_NOT_AUTHORIZED)
-    (map-delete agent-wallets {agent-id: agent-id})
-    (print {
-      notification: "identity-registry/MetadataSet",
-      payload: {
-        agent-id: agent-id,
-        key: RESERVED_KEY_AGENT_WALLET,
-        value-len: u0
-      }
-    })
+    (clear-agent-wallet agent-id)
     (ok true)
   )
 )
@@ -281,19 +280,13 @@
     (asserts! (is-eq tx-sender sender) ERR_INVALID_SENDER)
     (let ((actual-owner (unwrap! (nft-get-owner? agent-identity token-id) ERR_AGENT_NOT_FOUND)))
       (asserts! (is-eq sender actual-owner) ERR_NOT_AUTHORIZED)
-      ;; Clear agent wallet before transfer
-      (map-delete agent-wallets {agent-id: token-id})
-      (print {
-        notification: "identity-registry/MetadataSet",
-        payload: {
-          agent-id: token-id,
-          key: RESERVED_KEY_AGENT_WALLET,
-          value-len: u0
-        }
-      })
+      ;; Clear agent wallet and reverse lookup before transfer
+      (clear-agent-wallet token-id)
+      ;; Set reverse lookup for new owner
+      (map-set agent-id-by-owner recipient token-id)
       (try! (nft-transfer? agent-identity token-id sender recipient))
       (print {
-        notification: "identity-registry/Transfer",
+        notification: "Transfer",
         payload: {
           token-id: token-id,
           sender: sender,
@@ -325,12 +318,16 @@
   (default-to false (map-get? approvals {agent-id: agent-id, operator: operator}))
 )
 
+(define-read-only (get-agent-id-by-owner (owner principal))
+  (map-get? agent-id-by-owner owner)
+)
+
 (define-read-only (get-version)
   VERSION
 )
 
 (define-read-only (get-agent-wallet (agent-id uint))
-  (map-get? agent-wallets {agent-id: agent-id})
+  (map-get? agent-wallets agent-id)
 )
 
 (define-read-only (is-authorized-or-owner (spender principal) (agent-id uint))
@@ -366,6 +363,27 @@
 
 ;; private functions
 
+(define-private (clear-agent-wallet (agent-id uint))
+  (let (
+    (wallet-opt (map-get? agent-wallets agent-id))
+  )
+    (map-delete agent-wallets agent-id)
+    ;; Clear reverse lookup if wallet was set
+    (match wallet-opt wallet
+      (map-delete agent-id-by-owner wallet)
+      false
+    )
+    (print {
+      notification: "MetadataSet",
+      payload: {
+        agent-id: agent-id,
+        key: RESERVED_KEY_AGENT_WALLET,
+        value-len: u0
+      }
+    })
+  )
+)
+
 (define-private (metadata-fold-entry
   (entry {key: (string-utf8 128), value: (buff 512)})
   (prior-acc {agent-id: uint, success: bool, reserved-key-found: bool})
@@ -383,7 +401,7 @@
         )
           (map-set metadata {agent-id: aid, key: k} v)
           (print {
-            notification: "identity-registry/MetadataSet",
+            notification: "MetadataSet",
             payload: {
               agent-id: aid,
               key: k,

```

</details>
